### PR TITLE
Fix:arrow right icon switch theme

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
+import { MoveRight } from "lucide-react"; //Added icon from lucide react
 
 const ArrowIcon = () => (
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" style={{width: '16px', height: '16px'}} className="w-4 h-4"><path d="m17.5 5.999-.707.707 5.293 5.293H1v1h21.086l-5.294 5.295.707.707L24 12.499l-6.5-6.5z" data-name="Right"/></svg>
+<MoveRight className="w-4 h-4 text-gray-800 dark:text-gray-200" /> // updated styles when light mode text-gray-800 and when dark mode text-gray-200
 );
 
 


### PR DESCRIPTION
Added lucid react arrow right icon and updated styling so that it works with both light and dark mode .

![Screenshot (145)](https://github.com/user-attachments/assets/8b21b900-5483-468f-843e-9346844a8308)
![Screenshot (144)](https://github.com/user-attachments/assets/03ab058a-2094-4cfd-8134-5d4612b5c67e)

